### PR TITLE
[Bugfix]: Fix single view for references

### DIFF
--- a/theme-defaults/casawp/bootstrap3/single.phtml
+++ b/theme-defaults/casawp/bootstrap3/single.phtml
@@ -33,7 +33,9 @@
 			?>
 		</div>
 		<div class="casawp-single-aside-container">
-			<?php echo $offer->renderContactform(); ?>
+			<?php if ($offer->getAvailability() !== 'reference'): ?>
+				<?php echo $offer->renderContactform(); ?>
+			<?php endif; ?>
 		</div>
 		<div class="casawp-single-aside-container">
 			<?php echo $offer->renderSeller(); ?>


### PR DESCRIPTION
Hey,
I've recently found a bug in your single template by using the following shortcode: `[casawp_properties order="ASC" col_count="1" availabilities="reference"]`

It's caused because `availabilities="reference"` do not have a contact form, so it's unable to read props of the `$form` variable.

So I've quickfixed it by adding a condition around the form renderer. I'm not sure if it also applies to other parameter in the shortcode or other templates like bootstrap 4 or whatever. So maybe you need to modify the fix.